### PR TITLE
Build DependencyInjection extension in Release mode

### DIFF
--- a/Generator.props
+++ b/Generator.props
@@ -41,6 +41,6 @@
 	</Target>
 
 	<ItemGroup>
-		<None Include="../LICENSE" Pack="true"  PackagePath=""/>
+		<None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true"  PackagePath=""/>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
The relative path ../LICENSE only works for projects one level deep. Using $(MSBuildThisFileDirectory)LICENSE ensures the correct path for projects at any nesting level, including extensions/.
