### PR TITLE
fix(configuration): resolve build errors in Configuration extension

### DIFF
--- a/TeCLI.Tools/TeCLI.Tools.csproj
+++ b/TeCLI.Tools/TeCLI.Tools.csproj
@@ -29,7 +29,7 @@
 
 	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 	</ItemGroup>
 </Project>

--- a/TeCLI/Generators/CommandLineArgsGenerator.Commands.cs
+++ b/TeCLI/Generators/CommandLineArgsGenerator.Commands.cs
@@ -340,7 +340,9 @@ public partial class CommandLineArgsGenerator
             Block(ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("Console"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("System"),
+                            IdentifierName("Console")),
                         IdentifierName("WriteLine")))
                 .WithArgumentList(ArgumentList(SingletonSeparatedList(
                     Argument(InvocationExpression(
@@ -358,7 +360,9 @@ public partial class CommandLineArgsGenerator
             ElseClause(Block(ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("Console"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("System"),
+                            IdentifierName("Console")),
                         IdentifierName("WriteLine")))
                 .WithArgumentList(ArgumentList(SingletonSeparatedList(
                     Argument(InvocationExpression(

--- a/TeCLI/Generators/CommandLineArgsGenerator.Completion.cs
+++ b/TeCLI/Generators/CommandLineArgsGenerator.Completion.cs
@@ -86,7 +86,9 @@ public partial class CommandLineArgsGenerator
                                 InvocationExpression(
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName("Console"),
+                                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                                IdentifierName("System"),
+                                                IdentifierName("Console")),
                                             IdentifierName("Error")),
                                         IdentifierName("WriteLine")))
                                 .WithArgumentList(ArgumentList(SingletonSeparatedList(
@@ -101,7 +103,9 @@ public partial class CommandLineArgsGenerator
                                 InvocationExpression(
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName("Console"),
+                                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                                IdentifierName("System"),
+                                                IdentifierName("Console")),
                                             IdentifierName("Error")),
                                         IdentifierName("WriteLine")))
                                 .WithArgumentList(ArgumentList(SingletonSeparatedList(
@@ -192,7 +196,9 @@ public partial class CommandLineArgsGenerator
             ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("Console"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("System"),
+                            IdentifierName("Console")),
                         IdentifierName("WriteLine")))
                 .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("script"))))))
         };
@@ -322,7 +328,9 @@ public partial class CommandLineArgsGenerator
             ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("Console"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("System"),
+                            IdentifierName("Console")),
                         IdentifierName("WriteLine")))
                 .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("script"))))))
         };
@@ -426,7 +434,9 @@ public partial class CommandLineArgsGenerator
             ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("Console"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("System"),
+                            IdentifierName("Console")),
                         IdentifierName("WriteLine")))
                 .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("script"))))))
         };
@@ -476,7 +486,9 @@ public partial class CommandLineArgsGenerator
             ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName("Console"),
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("System"),
+                            IdentifierName("Console")),
                         IdentifierName("WriteLine")))
                 .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("script"))))))
         };

--- a/TeCLI/TeCLI.csproj
+++ b/TeCLI/TeCLI.csproj
@@ -18,8 +18,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 
 		<ProjectReference Include="..\TeCLI.Tools\TeCLI.Tools.csproj" />
 	</ItemGroup>

--- a/examples/TeCLI.Example.Autofac/TeCLI.Example.Autofac.csproj
+++ b/examples/TeCLI.Example.Autofac/TeCLI.Example.Autofac.csproj
@@ -20,4 +20,8 @@
 	</ItemGroup>
 
 	<Import Project="..\..\extensions\TeCLI.Extensions.Autofac\TeCLI.Extensions.Autofac.props" />
+
+	<ItemGroup>
+	  <PackageReference Update="Autofac" Version="9.0.0" />
+	</ItemGroup>
 </Project>

--- a/examples/TeCLI.Example.Jab/TeCLI.Example.Jab.csproj
+++ b/examples/TeCLI.Example.Jab/TeCLI.Example.Jab.csproj
@@ -20,4 +20,8 @@
 	</ItemGroup>
 
 	<Import Project="..\..\extensions\TeCLI.Extensions.Jab\TeCLI.Extensions.Jab.props" />
+
+	<ItemGroup>
+	  <PackageReference Update="Jab" Version="0.12.0" />
+	</ItemGroup>
 </Project>

--- a/examples/TeCLI.Example.Localization/GreetCommand.cs
+++ b/examples/TeCLI.Example.Localization/GreetCommand.cs
@@ -2,6 +2,8 @@ using TeCLI.Attributes;
 using TeCLI.Localization;
 using TeCLI.Example.Localization.Resources;
 
+namespace TeCLI.Example.Localization;
+
 /// <summary>
 /// Example command demonstrating localization support.
 /// Uses LocalizedDescription attributes for i18n descriptions.

--- a/examples/TeCLI.Example.PureDI/TeCLI.Example.PureDI.csproj
+++ b/examples/TeCLI.Example.PureDI/TeCLI.Example.PureDI.csproj
@@ -20,4 +20,11 @@
 	</ItemGroup>
 
 	<Import Project="..\..\extensions\TeCLI.Extensions.PureDI\TeCLI.Extensions.PureDI.props" />
+
+	<ItemGroup>
+	  <PackageReference Update="Pure.DI" Version="2.2.14">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
 </Project>

--- a/examples/TeCLI.Example.SimpleInjector/TeCLI.Example.SimpleInjector.csproj
+++ b/examples/TeCLI.Example.SimpleInjector/TeCLI.Example.SimpleInjector.csproj
@@ -20,4 +20,8 @@
 	</ItemGroup>
 
 	<Import Project="..\..\extensions\TeCLI.Extensions.SimpleInjector\TeCLI.Extensions.SimpleInjector.props" />
+
+	<ItemGroup>
+	  <PackageReference Update="SimpleInjector" Version="5.5.0" />
+	</ItemGroup>
 </Project>

--- a/extensions/TeCLI.Extensions.Autofac/TeCLI.Extensions.Autofac.csproj
+++ b/extensions/TeCLI.Extensions.Autofac/TeCLI.Extensions.Autofac.csproj
@@ -19,13 +19,13 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="Autofac" Version="6.5.0" />
+		<PackageReference Include="Autofac" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 
 		<ProjectReference Include="..\..\TeCLI.Tools\TeCLI.Tools.csproj" />
 	</ItemGroup>

--- a/extensions/TeCLI.Extensions.Configuration.Analyzers/TeCLI.Extensions.Configuration.Analyzers.csproj
+++ b/extensions/TeCLI.Extensions.Configuration.Analyzers/TeCLI.Extensions.Configuration.Analyzers.csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -31,20 +31,16 @@
 
 	<Target Name="MoveNugetPackage" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
 		<ItemGroup>
-			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg"/>
+			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg" />
 		</ItemGroup>
 
-		<Copy
-            SourceFiles="@(NugetFiles)"
-            DestinationFolder="..\..\.packages\"
-			ContinueOnError="true"
-        />
+		<Copy SourceFiles="@(NugetFiles)" DestinationFolder="..\..\.packages\" ContinueOnError="true" />
 
 		<Message Text="Copied nupkg to repo directory." Importance="high" />
 	</Target>
 
 	<ItemGroup>
-		<None Include="../../LICENSE" Pack="true" PackagePath=""/>
+		<None Include="../../LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 </Project>

--- a/extensions/TeCLI.Extensions.Configuration/ConfigurationLoader.cs
+++ b/extensions/TeCLI.Extensions.Configuration/ConfigurationLoader.cs
@@ -269,10 +269,17 @@ public class ConfigurationLoader
             if (underlyingType.IsEnum)
             {
                 var stringValue = value.ToString();
-                if (!string.IsNullOrEmpty(stringValue) &&
-                    Enum.TryParse(underlyingType, stringValue, ignoreCase: true, out var enumValue))
+                if (!string.IsNullOrEmpty(stringValue))
                 {
-                    return (T)enumValue!;
+                    try
+                    {
+                        var enumValue = Enum.Parse(underlyingType, stringValue, ignoreCase: true);
+                        return (T)enumValue;
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Invalid enum value, fall through to Convert
+                    }
                 }
             }
 

--- a/extensions/TeCLI.Extensions.Configuration/Parsers/TomlConfigurationParser.cs
+++ b/extensions/TeCLI.Extensions.Configuration/Parsers/TomlConfigurationParser.cs
@@ -32,7 +32,7 @@ public class TomlConfigurationParser : IConfigurationParser
         }
 
         var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        var currentSection = result;
+        IDictionary<string, object?> currentSection = result;
         var currentSectionPath = new List<string>();
 
         var lines = content.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);

--- a/extensions/TeCLI.Extensions.Configuration/TeCLI.Extensions.Configuration.csproj
+++ b/extensions/TeCLI.Extensions.Configuration/TeCLI.Extensions.Configuration.csproj
@@ -18,25 +18,21 @@
 
 	<Target Name="MoveNugetPackage" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
 		<ItemGroup>
-			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg"/>
+			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg" />
 		</ItemGroup>
 
-		<Copy
-            SourceFiles="@(NugetFiles)"
-            DestinationFolder="..\..\.packages\"
-			ContinueOnError="true"
-        />
+		<Copy SourceFiles="@(NugetFiles)" DestinationFolder="..\..\.packages\" ContinueOnError="true" />
 
 		<Message Text="Copied nupkg to repo directory." Importance="high" />
 	</Target>
 
 	<ItemGroup>
-		<None Include="../../LICENSE" Pack="true" PackagePath=""/>
+		<None Include="../../LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 	<!-- JSON support is built-in via System.Text.Json -->
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="System.Text.Json" Version="6.0.0" />
+		<PackageReference Include="System.Text.Json" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/extensions/TeCLI.Extensions.Console.Analyzers/TeCLI.Extensions.Console.Analyzers.csproj
+++ b/extensions/TeCLI.Extensions.Console.Analyzers/TeCLI.Extensions.Console.Analyzers.csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -31,20 +31,16 @@
 
 	<Target Name="MoveNugetPackage" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
 		<ItemGroup>
-			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg"/>
+			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg" />
 		</ItemGroup>
 
-		<Copy
-            SourceFiles="@(NugetFiles)"
-            DestinationFolder="..\..\.packages\"
-			ContinueOnError="true"
-        />
+		<Copy SourceFiles="@(NugetFiles)" DestinationFolder="..\..\.packages\" ContinueOnError="true" />
 
 		<Message Text="Copied nupkg to repo directory." Importance="high" />
 	</Target>
 
 	<ItemGroup>
-		<None Include="../../LICENSE" Pack="true" PackagePath=""/>
+		<None Include="../../LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 </Project>

--- a/extensions/TeCLI.Extensions.DependencyInjection/TeCLI.Extensions.DependencyInjection.csproj
+++ b/extensions/TeCLI.Extensions.DependencyInjection/TeCLI.Extensions.DependencyInjection.csproj
@@ -19,13 +19,13 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 
 		<ProjectReference Include="..\..\TeCLI.Tools\TeCLI.Tools.csproj" />
 	</ItemGroup>

--- a/extensions/TeCLI.Extensions.Jab/TeCLI.Extensions.Jab.csproj
+++ b/extensions/TeCLI.Extensions.Jab/TeCLI.Extensions.Jab.csproj
@@ -20,8 +20,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 
 		<ProjectReference Include="..\..\TeCLI.Tools\TeCLI.Tools.csproj" />
 	</ItemGroup>

--- a/extensions/TeCLI.Extensions.Localization.Analyzers/TeCLI.Extensions.Localization.Analyzers.csproj
+++ b/extensions/TeCLI.Extensions.Localization.Analyzers/TeCLI.Extensions.Localization.Analyzers.csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -31,20 +31,16 @@
 
 	<Target Name="MoveNugetPackage" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
 		<ItemGroup>
-			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg"/>
+			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg" />
 		</ItemGroup>
 
-		<Copy
-            SourceFiles="@(NugetFiles)"
-            DestinationFolder="..\..\.packages\"
-			ContinueOnError="true"
-        />
+		<Copy SourceFiles="@(NugetFiles)" DestinationFolder="..\..\.packages\" ContinueOnError="true" />
 
 		<Message Text="Copied nupkg to repo directory." Importance="high" />
 	</Target>
 
 	<ItemGroup>
-		<None Include="../../LICENSE" Pack="true" PackagePath=""/>
+		<None Include="../../LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 </Project>

--- a/extensions/TeCLI.Extensions.Output/Formatters/JsonOutputFormatter.cs
+++ b/extensions/TeCLI.Extensions.Output/Formatters/JsonOutputFormatter.cs
@@ -15,7 +15,7 @@ public class JsonOutputFormatter : IOutputFormatter
     private readonly JsonSerializerOptions _options;
 
     /// <inheritdoc />
-    public OutputFormat Format => OutputFormat.Json;
+    public OutputFormat OutputFormat => OutputFormat.Json;
 
     /// <inheritdoc />
     public string FileExtension => ".json";

--- a/extensions/TeCLI.Extensions.Output/Formatters/TableOutputFormatter.cs
+++ b/extensions/TeCLI.Extensions.Output/Formatters/TableOutputFormatter.cs
@@ -16,7 +16,7 @@ namespace TeCLI.Output.Formatters;
 public class TableOutputFormatter : IOutputFormatter
 {
     /// <inheritdoc />
-    public OutputFormat Format => OutputFormat.Table;
+    public OutputFormat OutputFormat => OutputFormat.Table;
 
     /// <inheritdoc />
     public string FileExtension => ".txt";

--- a/extensions/TeCLI.Extensions.Output/Formatters/XmlOutputFormatter.cs
+++ b/extensions/TeCLI.Extensions.Output/Formatters/XmlOutputFormatter.cs
@@ -15,7 +15,7 @@ namespace TeCLI.Output.Formatters;
 public class XmlOutputFormatter : IOutputFormatter
 {
     /// <inheritdoc />
-    public OutputFormat Format => OutputFormat.Xml;
+    public OutputFormat OutputFormat => OutputFormat.Xml;
 
     /// <inheritdoc />
     public string FileExtension => ".xml";

--- a/extensions/TeCLI.Extensions.Output/Formatters/YamlOutputFormatter.cs
+++ b/extensions/TeCLI.Extensions.Output/Formatters/YamlOutputFormatter.cs
@@ -15,7 +15,7 @@ namespace TeCLI.Output.Formatters;
 public class YamlOutputFormatter : IOutputFormatter
 {
     /// <inheritdoc />
-    public OutputFormat Format => OutputFormat.Yaml;
+    public OutputFormat OutputFormat => OutputFormat.Yaml;
 
     /// <inheritdoc />
     public string FileExtension => ".yaml";

--- a/extensions/TeCLI.Extensions.Output/IOutputFormatter.cs
+++ b/extensions/TeCLI.Extensions.Output/IOutputFormatter.cs
@@ -12,7 +12,7 @@ public interface IOutputFormatter
     /// <summary>
     /// Gets the output format this formatter handles.
     /// </summary>
-    OutputFormat Format { get; }
+    OutputFormat OutputFormat { get; }
 
     /// <summary>
     /// Gets the file extension associated with this format (e.g., ".json", ".xml").
@@ -48,7 +48,7 @@ public interface IOutputFormatter
 /// <code>
 /// public class UserCsvFormatter : IOutputFormatter&lt;User&gt;
 /// {
-///     public OutputFormat Format => OutputFormat.Csv;
+///     public OutputFormat OutputFormat => OutputFormat.Csv;
 ///     public string FileExtension => ".csv";
 ///     public string MimeType => "text/csv";
 ///

--- a/extensions/TeCLI.Extensions.Output/OutputFormatterRegistry.cs
+++ b/extensions/TeCLI.Extensions.Output/OutputFormatterRegistry.cs
@@ -49,7 +49,7 @@ public class OutputFormatterRegistry
         if (formatter == null)
             throw new ArgumentNullException(nameof(formatter));
 
-        _formatters[formatter.Format] = formatter;
+        _formatters[formatter.OutputFormat] = formatter;
     }
 
     /// <summary>

--- a/extensions/TeCLI.Extensions.PureDI/TeCLI.Extensions.PureDI.csproj
+++ b/extensions/TeCLI.Extensions.PureDI/TeCLI.Extensions.PureDI.csproj
@@ -20,8 +20,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 
 		<ProjectReference Include="..\..\TeCLI.Tools\TeCLI.Tools.csproj" />
 	</ItemGroup>

--- a/extensions/TeCLI.Extensions.Shell.Analyzers/TeCLI.Extensions.Shell.Analyzers.csproj
+++ b/extensions/TeCLI.Extensions.Shell.Analyzers/TeCLI.Extensions.Shell.Analyzers.csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -31,20 +31,16 @@
 
 	<Target Name="MoveNugetPackage" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
 		<ItemGroup>
-			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg"/>
+			<NugetFiles Include="bin\**\$(MSBuildProjectName).*.nupkg" />
 		</ItemGroup>
 
-		<Copy
-            SourceFiles="@(NugetFiles)"
-            DestinationFolder="..\..\.packages\"
-			ContinueOnError="true"
-        />
+		<Copy SourceFiles="@(NugetFiles)" DestinationFolder="..\..\.packages\" ContinueOnError="true" />
 
 		<Message Text="Copied nupkg to repo directory." Importance="high" />
 	</Target>
 
 	<ItemGroup>
-		<None Include="../../LICENSE" Pack="true" PackagePath=""/>
+		<None Include="../../LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 </Project>

--- a/extensions/TeCLI.Extensions.Shell/CommandHistory.cs
+++ b/extensions/TeCLI.Extensions.Shell/CommandHistory.cs
@@ -219,7 +219,7 @@ public class CommandHistory
         try
         {
             var lines = File.ReadAllLines(_historyFile);
-            foreach (var line in lines.TakeLast(_maxSize))
+            foreach (var line in lines.Skip(Math.Max(0, lines.Length - _maxSize)))
             {
                 if (!string.IsNullOrWhiteSpace(line))
                 {
@@ -247,7 +247,7 @@ public class CommandHistory
                 Directory.CreateDirectory(directory);
             }
 
-            File.WriteAllLines(_historyFile, _history.TakeLast(_maxSize));
+            File.WriteAllLines(_historyFile, _history.Skip(Math.Max(0, _history.Count - _maxSize)));
         }
         catch
         {

--- a/extensions/TeCLI.Extensions.Shell/LineEditor.cs
+++ b/extensions/TeCLI.Extensions.Shell/LineEditor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace TeCLI.Shell;

--- a/extensions/TeCLI.Extensions.SimpleInjector/TeCLI.Extensions.SimpleInjector.csproj
+++ b/extensions/TeCLI.Extensions.SimpleInjector/TeCLI.Extensions.SimpleInjector.csproj
@@ -19,13 +19,13 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="SimpleInjector" Version="5.4.6" />
+		<PackageReference Include="SimpleInjector" Version="5.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
 
 		<ProjectReference Include="..\..\TeCLI.Tools\TeCLI.Tools.csproj" />
 	</ItemGroup>

--- a/tests/TeCLI.Extensions.Configuration.Tests/TeCLI.Extensions.Configuration.Tests.csproj
+++ b/tests/TeCLI.Extensions.Configuration.Tests/TeCLI.Extensions.Configuration.Tests.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/TeCLI.Extensions.Console.Tests/TeCLI.Extensions.Console.Tests.csproj
+++ b/tests/TeCLI.Extensions.Console.Tests/TeCLI.Extensions.Console.Tests.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/TeCLI.Extensions.Localization.Tests/TeCLI.Extensions.Localization.Tests.csproj
+++ b/tests/TeCLI.Extensions.Localization.Tests/TeCLI.Extensions.Localization.Tests.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/TeCLI.Extensions.Shell.Tests/TeCLI.Extensions.Shell.Tests.csproj
+++ b/tests/TeCLI.Extensions.Shell.Tests/TeCLI.Extensions.Shell.Tests.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/TeCLI.Extensions.Testing.Tests/TeCLI.Extensions.Testing.Tests.csproj
+++ b/tests/TeCLI.Extensions.Testing.Tests/TeCLI.Extensions.Testing.Tests.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0" />
+		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/TeCLI.Tests/CompletionGenerationTests.cs
+++ b/tests/TeCLI.Tests/CompletionGenerationTests.cs
@@ -16,7 +16,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "bash" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -36,7 +36,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "zsh" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -55,7 +55,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "powershell" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -75,7 +75,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "fish" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -93,7 +93,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "unknown-shell" };
         var errorOutput = new StringWriter();
-        Console.SetError(errorOutput);
+        System.Console.SetError(errorOutput);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -111,7 +111,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "bash" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -130,7 +130,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "zsh" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -148,7 +148,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "powershell" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -166,7 +166,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "fish" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -184,7 +184,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "BASH" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -201,7 +201,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "ZSH" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -218,7 +218,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "PowerShell" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();
@@ -235,7 +235,7 @@ public class CompletionGenerationTests
         // Arrange
         var args = new[] { "--generate-completion", "FISH" };
         var output = new StringWriter();
-        Console.SetOut(output);
+        System.Console.SetOut(output);
 
         // Act
         var dispatcher = new TeCLI.CommandDispatcher();

--- a/tests/TeCLI.Tests/TeCLI.Tests.csproj
+++ b/tests/TeCLI.Tests/TeCLI.Tests.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Shouldly" Version="4.3.0" />
-		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0" />
+		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Fix TomlConfigurationParser.cs: Use IDictionary<string, object?>
  instead of Dictionary for currentSection variable to match the
  return types of GetOrCreateSection and GetOrCreateArrayTable methods

- Fix ConfigurationLoader.cs: Replace Enum.TryParse(Type, ...) with Enum.Parse wrapped in try-catch for netstandard2.0 compatibility. The non-generic TryParse overload is not available in netstandard2.0
